### PR TITLE
Several changes for chapters 3 and 4

### DIFF
--- a/ansible/chapter3/authorized_keys.yml
+++ b/ansible/chapter3/authorized_keys.yml
@@ -2,6 +2,5 @@
   authorized_key:
     user: bender 
     state: present
-    #key: "{{ lookup('file', '/home/charlie/.ssh/dftd.pub') }}"
     key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/dftd.pub') }}"
 

--- a/ansible/chapter4/sudoers.yml
+++ b/ansible/chapter4/sudoers.yml
@@ -2,8 +2,11 @@
 - set_fact:
     greeting_application_file: "/opt/engineering/greeting.py"
 
-- name: Create Sudoers file for developers group
+- name: Create sudoers file for developers group
   template:
     src: "../ansible/templates/developers.j2"
     dest: "/etc/sudoers.d/developers"
     validate: 'visudo -cf %s'
+    owner: root
+    group: root
+    mode: 0440

--- a/ansible/chapter4/web_application.yml
+++ b/ansible/chapter4/web_application.yml
@@ -1,10 +1,11 @@
 ---
-- name: Install python3-flask and gunicorn3
+- name: Install python3-flask, gunicorn3, and nginx
   apt:
-    pkg:
-    - python3-flask
-    - gunicorn
-    - nginx
+    name:
+      - python3-flask
+      - gunicorn
+      - nginx
+    update_cache: yes
 
 - name: Copy Flask Sample Application
   copy:
@@ -16,13 +17,14 @@
     - greeting.py
     - wsgi.py
 
-- name: Copy Systemd Unit file for Greeting
+- name: Copy systemd Unit file for Greeting
   copy:
     src: "../ansible/chapter4/greeting.service"
     dest: "/etc/systemd/system/greeting.service"
 
-- name: (Re)Start Greetings Application
+- name: Start and enable Greetings Application
   systemd:
     name: greeting.service
     daemon_reload: yes
     state: started
+    enabled: yes

--- a/ansible/templates/developers.j2
+++ b/ansible/templates/developers.j2
@@ -1,8 +1,14 @@
 # Command alias
-Cmnd_Alias	START_GREETING =/bin/systemctl start greeting
-Cmnd_Alias	STOP_GREETING  =/bin/systemctl stop greeting
+Cmnd_Alias	START_GREETING    = /bin/systemctl start greeting , \
+				    /bin/systemctl start greeting.service
+Cmnd_Alias	STOP_GREETING     = /bin/systemctl stop greeting , \
+				    /bin/systemctl stop greeting.service
+Cmnd_Alias	RESTART_GREETING  = /bin/systemctl restart greeting , \
+				    /bin/systemctl restart greeting.service
 
 # Host Alias
 Host_Alias      LOCAL_VM = {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
 # User specification
-%developers LOCAL_VM = (root) NOPASSWD: START_GREETING,STOP_GREETING,sudoedit {{ greeting_application_file }}
+%developers LOCAL_VM = (root) NOPASSWD: START_GREETING, STOP_GREETING, \
+	    	       RESTART_GREETING, \
+		       sudoedit {{ greeting_application_file }}


### PR DESCRIPTION
+ authorized_keys.yml: Remove unneeded comment

+ sudoers.yml: Enforce ownership/mode, cosmetic changes

+ developer.j2 (sudoers): Add a Cmnd_Alias for ‘systemctl restart’, as
  well as the more explicit ‘greeting.service’ notation.

+ web_application.yml: Use ‘name’ instead of ‘pkg’ b/c ‘pkg’ is an
  alias for ‘name’.  Enable greeting.service so that it starts on
  boot.  Cosmetic changes.