### PR TITLE
update cronjob api version for k8s 1.21

### DIFF
--- a/monitoring/bbs-warrior/cron_job.yaml
+++ b/monitoring/bbs-warrior/cron_job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: bbs-warrior


### PR DESCRIPTION
k8s 1.21 + uses v1 for CronJob.