### PR TITLE
Enable keyboard-interactive ssh authentication

### DIFF
--- a/ansible/chapter3/two_factor.yml
+++ b/ansible/chapter3/two_factor.yml
@@ -23,6 +23,12 @@
     dest: "/etc/pam.d/sshd"
     line: "auth required pam_google_authenticator.so nullok"
 
+- name: Enable keyboard-interactive authentication
+  lineinfile:
+    dest: "/etc/ssh/sshd_config"
+    regexp: "^KbdInteractiveAuthentication (yes|no)"
+    line: "KbdInteractiveAuthentication yes"
+
 - name: Set ChallengeResponseAuthentication to Yes
   lineinfile:
     dest: "/etc/ssh/sshd_config"


### PR DESCRIPTION
At the end of the chapter 3, I can't authenticate the bender user as the keyboard-interactive authentication method was disabled on my VM.
I am using the last Ubuntu LTS version (ubuntu/jammy64). Maybe the parameter KbdInteractiveAuthentication was set to yes by default on ubuntu/focal64.
I enjoy the book by the way.