### PR TITLE
container-structure-test use envVar instead of env

### DIFF
--- a/telnet-server/container-tests/command-and-metadata-test.yaml
+++ b/telnet-server/container-tests/command-and-metadata-test.yaml
@@ -5,7 +5,7 @@ commandTests:
     args: ["-i"]
     expectedOutput: ["telnet port :2323\nMetrics Port: :9000"]
 metadataTest:
-  env:
+  envVars:
     - key: TELNET_PORT
       value: 2323
     - key: METRIC_PORT


### PR DESCRIPTION
This change seems to have been pushed on container-structure-test project 10 days ago: https://github.com/GoogleContainerTools/container-structure-test/pull/314