### PR TITLE
Update env to envVars

### DIFF
--- a/telnet-server/container-tests/command-and-metadata-test.yaml
+++ b/telnet-server/container-tests/command-and-metadata-test.yaml
@@ -5,7 +5,7 @@ commandTests:
     args: ["-i"]
     expectedOutput: ["telnet port :2323\nMetrics Port: :9000"]
 metadataTest:
-  env:
+  envVars:
     - key: TELNET_PORT
       value: 2323
     - key: METRIC_PORT


### PR DESCRIPTION
`metadataTest` no longer supports `env` field.

See docs here: https://github.com/GoogleContainerTools/container-structure-test#command-tests